### PR TITLE
Initialize backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # langchainCAD
-CAD drawing analysis through VLM
+
+CAD drawing analysis through VLM.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python run.py
+   ```
+
+## Project Structure
+
+- `app/` - Flask application package
+  - `api/` - API layer using blueprints
+  - `services/` - Business logic and algorithm deployment
+  - `relay/` - Interfaces for calling VLM/LLM models
+- `run.py` - Entry point for running the Flask server
+
+This is a minimal skeleton to get started. Replace stub functions with real implementations.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+from flask_cors import CORS
+
+
+def create_app():
+    app = Flask(__name__)
+    CORS(app)
+
+    from .api import api_blueprint
+    app.register_blueprint(api_blueprint, url_prefix='/api')
+
+    return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, request, jsonify
+
+api_blueprint = Blueprint('api', __name__)
+
+
+@api_blueprint.route('/analyze', methods=['POST'])
+def analyze_cad():
+    data = request.get_json()
+    # TODO: validate and process data
+
+    # Example service call
+    from ..services.cad_service import analyze
+    result = analyze(data)
+
+    return jsonify(result)

--- a/app/relay/vlm_client.py
+++ b/app/relay/vlm_client.py
@@ -1,0 +1,7 @@
+"""Module responsible for forwarding requests to the VLM/LLM model."""
+
+
+def call_vlm(payload):
+    """Stub call to VLM model. Replace with actual API request."""
+    # TODO: integrate with real VLM or LLM service
+    return {"status": "success", "payload": payload}

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service layer package."""
+
+from .cad_service import analyze

--- a/app/services/cad_service.py
+++ b/app/services/cad_service.py
@@ -1,0 +1,10 @@
+"""CAD-related service functions."""
+
+from ..relay.vlm_client import call_vlm
+
+
+def analyze(data):
+    """Stub function to analyze CAD data."""
+    # TODO: implement business logic
+    response = call_vlm(data)
+    return {"message": "analysis result", "vlm_response": response}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flask-cors

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- set up Flask application with CORS
- add blueprint for `/api/analyze`
- add service and relay stubs
- add requirements and update README

## Testing
- `python -m py_compile run.py app/__init__.py app/api/__init__.py app/services/__init__.py app/services/cad_service.py app/relay/__init__.py app/relay/vlm_client.py`


------
https://chatgpt.com/codex/tasks/task_e_685db26926308332a268eec2afbb1e33